### PR TITLE
Add support for multiple heads

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,10 @@
 | `interval` _(optional)_ | Polling time for thermostat (Default: 60 sec.) |
 | `region` _(optional)_ | Region for thermostat, change for China & E.U. (Default: "us") |
 
-##New Features
-- Added China and European servers for API, change region to
-- Improved update speed when changing modes / temps in Home App
+## New Features
+- Works with multiple air conditioner heads.
 
 ## Current limitations
-- Only one air conditioner is displayed, the API chooses the first device.  I only have one system, so feel free to contribute changes if you have more than one A/C unit.
 - Timeout on token is not enabled, when token is invalid the API will re-authenticate.
 - Auth. Token is not cached (Future Release)
 - Previous thermostat state is not cached (Future Release)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 | `name` | Name to appear in the Home app |
 | `username` | FGLair Username |
 | `password` | FGLair Password |
+| `deviceIndex` _(optional)_ | The index of the device this plugin will control (in the order in which you added them to your FGLair account) |
 | `model` _(optional)_ | Appears under "Model" for your accessory in the Home app |
 | `interval` _(optional)_ | Polling time for thermostat (Default: 60 sec.) |
 | `region` _(optional)_ | Region for thermostat, change for China & E.U. (Default: "us") |

--- a/config.schema.json
+++ b/config.schema.json
@@ -26,6 +26,13 @@
                 "default": "",
                 "description": "Password for FGLair App"
             },
+			"deviceIndex": {
+				"title": "Device Index",
+				"type": "string",
+				"required": false,
+				"default": "0",
+				"description": "The index of the device this plugin will control (in the order in which you added them to your FGLair account)"
+			},
             "interval": {
                 "title": "Update Interval",
                 "type": "string",

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function Thermostat(log, config) {
     this.token = config.token || "";
     this.region = config.region || 'us'
     this.temperatureDisplayUnits = config.temperatureDisplayUnits || 0;
+	this.deviceIndex = config.deviceIndex || 0;
 
     this.currentHumidity = config.currentHumidity || false;
     this.targetHumidity = config.targetHumidity || false;
@@ -66,7 +67,7 @@ function Thermostat(log, config) {
             else
             {
 
-                this.serial = data[0]; //Only one thermostat is supported
+                this.serial = data[this.deviceIndex]; //Only one thermostat is supported
                 this.updateAll(that);
                 setInterval( this.updateAll, this.interval, that );
             }
@@ -117,23 +118,6 @@ Thermostat.prototype.updateAll = function(ctx)
                             break;
                         default:
                             ctx.targetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.OFF;
-                            break;
-                    }
-
-                    switch(mode)
-                    {
-                        case "off":
-                            ctx.currentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.OFF;
-                            break;
-                        case "heat":
-                            ctx.currentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.HEAT;
-                            break;
-                        case "cool":
-                        case "fan":
-                            ctx.currentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.COOL;
-                            break;
-                        default:
-                            ctx.currentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.OFF;
                             break;
                     }
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (homebridge) {
     Service = homebridge.hap.Service;
     Characteristic = homebridge.hap.Characteristic;
     HbAPI = homebridge;
-    homebridge.registerAccessory("homebridge-fujitsu-2", "FGLairThermostat", Thermostat);
+    homebridge.registerAccessory("homebridge-fujitsu", "FGLairThermostat", Thermostat);
 };
 
 const OPERATION_MODE = { "off":0, "auto":2, "cool":3, "dry":4, "fan_only":5, "heat":6, 0:"off", 2:"auto", 3:"cool", 4:"dry", 5:"fan_only", 6:"heat"}

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function Thermostat(log, config) {
     this.token = config.token || "";
     this.region = config.region || 'us'
     this.temperatureDisplayUnits = config.temperatureDisplayUnits || 0;
-	this.deviceIndex = config.deviceIndex;
+	this.deviceIndex = config.deviceIndex || 0;
 
     this.currentHumidity = config.currentHumidity || false;
     this.targetHumidity = config.targetHumidity || false;

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function Thermostat(log, config) {
     this.token = config.token || "";
     this.region = config.region || 'us'
     this.temperatureDisplayUnits = config.temperatureDisplayUnits || 0;
-	this.deviceIndex = config.deviceIndex || 0;
+	this.deviceIndex = config.deviceIndex;
 
     this.currentHumidity = config.currentHumidity || false;
     this.targetHumidity = config.targetHumidity || false;
@@ -47,38 +47,14 @@ function Thermostat(log, config) {
 
     this.log(this.name);
     this.service = new Service.Thermostat(this.name);
+	this.informationService = new Service.AccessoryInformation();
     this.api = require('./fglairAPI.js')
     this.api.setLog(this.log);
     this.api.setToken(this.token);
     this.api.setRegion(this.region);
-
-    that = this;
-
-    this.api.getAuth(this.userName ,this.password, (err, token) =>
-    {
-        this.token = token;
-
-        this.api.getDevices(token, (err,data) =>
-        {
-            if( err)
-            {
-               //TODO:  Do something...
-            }
-            else
-            {
-
-                this.serial = data[this.deviceIndex]; //Only one thermostat is supported
-                this.updateAll(that);
-                setInterval( this.updateAll, this.interval, that );
-            }
-        });
-
-    });
-}
-
-Thermostat.prototype.updateAll = function(ctx)
-{
-    ctx.api.getDeviceProp(ctx.serial, (err,properties) =>
+	
+	this.updateAll = function(ctx) {
+		ctx.api.getDeviceProp(ctx.serial, (err,properties) =>
     {   if(err)
         {
             ctx.log("Update Properties: " + err.message);
@@ -95,7 +71,7 @@ Thermostat.prototype.updateAll = function(ctx)
                     //ctx.log("[" + ctx.serial + "] Got Temperature: "+ ctx.targetTemperature + ":" + ctx.currentTemperature);
                     ctx.service.updateCharacteristic(Characteristic.TargetTemperature, ctx.targetTemperature);
                     ctx.service.updateCharacteristic(Characteristic.CurrentTemperature, ctx.currentTemperature);
-                    this.keyTargetTemperature = prop['property']['key'];
+                    ctx.keyTargetTemperature = prop['property']['key'];
                 }
                 else if( prop['property']['name'] == 'operation_mode' )
                 {
@@ -121,7 +97,7 @@ Thermostat.prototype.updateAll = function(ctx)
                             break;
                     }
 
-                    this.keyCurrentHeatingCoolingState = prop['property']['key'];
+                    ctx.keyCurrentHeatingCoolingState = prop['property']['key'];
 
                     //ctx.log("[" + ctx.serial + "] Got HeatingCooling State: "+ ctx.targetHeatingCoolingState);
                     ctx.service.updateCharacteristic(Characteristic.CurrentHeatingCoolingState, ctx.currentHeatingCoolingState);
@@ -133,7 +109,30 @@ Thermostat.prototype.updateAll = function(ctx)
         }
 
     });
-};
+}
+	
+	this.api.getAuth(this.userName ,this.password, (err, token) =>
+	{
+		this.token = token;
+
+		this.api.getDevices(token, (err,data) =>
+		{
+			if( err)
+			{
+			   //TODO:  Do something...
+			}
+			else
+			{
+				this.serial = data[this.deviceIndex];
+				this.log("device serial for " + this.deviceIndex + ": " + this.serial);
+				this.updateAll(this);
+				this.log("updated all for " + this.deviceIndex);
+				setInterval( this.updateAll, this.interval, this );
+			}
+		});
+
+	});
+}
 
 Thermostat.prototype.getCurrentHeatingCoolingState = function(cb) {
     cb(null, this.currentHeatingCoolingState);

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (homebridge) {
     Service = homebridge.hap.Service;
     Characteristic = homebridge.hap.Characteristic;
     HbAPI = homebridge;
-    homebridge.registerAccessory("homebridge-fujitsu", "FGLairThermostat", Thermostat);
+    homebridge.registerAccessory("homebridge-fujitsu-2", "FGLairThermostat", Thermostat);
 };
 
 const OPERATION_MODE = { "off":0, "auto":2, "cool":3, "dry":4, "fan_only":5, "heat":6, 0:"off", 2:"auto", 3:"cool", 4:"dry", 5:"fan_only", 6:"heat"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-fujitsu",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "homebridge-fujitsu-2",
-  "version": "0.0.5",
+  "name": "homebridge-fujitsu",
+  "version": "0.0.6",
   "description": "Homebridge accessory for Fujistu Mini-Split AC systems",
   "main": "index.js",
   "scripts": {
@@ -8,13 +8,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/joelk/homebridge-fujitsu.git"
+    "url": "https://github.com/smithersDBQ/homebridge-fujitsu.git"
   },
   "keywords": [
     "homebridge-plugin",
     "homebridge"
   ],
-  "author": "Joel Kin",
+  "author": "Ryan Beggs",
   "license": "MIT",
   "dependencies": {
     "node-persist": "^3.0.5"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homebridge-fujitsu",
+  "name": "homebridge-fujitsu-2",
   "version": "0.0.5",
   "description": "Homebridge accessory for Fujistu Mini-Split AC systems",
   "main": "index.js",
@@ -8,13 +8,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/smithersDBQ/homebridge-fujitsu.git"
+    "url": "https://github.com/joelk/homebridge-fujitsu.git"
   },
   "keywords": [
     "homebridge-plugin",
     "homebridge"
   ],
-  "author": "Ryan Beggs",
+  "author": "Joel Kin",
   "license": "MIT",
   "dependencies": {
     "node-persist": "^3.0.5"


### PR DESCRIPTION
Kind of a quick and dirty solution--not ideal because it results in multiple API instances hanging on to multiple API keys. But it works.